### PR TITLE
Fix memory leaks

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -227,7 +227,7 @@ bufputc(struct buf *buf, char c) {
 /* bufrelease • decrease the reference count and free the buffer if needed */
 void
 bufrelease(struct buf *buf) {
-	if (!buf || !buf->unit || !buf->asize) return;
+	if (!buf) return;
 	buf->ref -= 1;
 	if (buf->ref == 0) {
 #ifdef BUFFER_STATS
@@ -241,7 +241,7 @@ bufrelease(struct buf *buf) {
 /* bufreset • frees internal data of the buffer */
 void
 bufreset(struct buf *buf) {
-	if (!buf || !buf->unit || !buf->asize) return;
+	if (!buf) return;
 #ifdef BUFFER_STATS
 	buffer_stat_alloc_bytes -= buf->asize;
 #endif

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1948,12 +1948,16 @@ static void expand_tabs(struct buf *ob, const char *line, size_t size)
 void
 ups_markdown(struct buf *ob, struct buf *ib, const struct mkd_renderer *rndrer, unsigned int extensions) {
 	struct link_ref *lr;
-	struct buf *text = bufnew(TEXT_UNIT);
+	struct buf *text;
 	size_t i, beg, end;
 	struct render rndr;
 
 	/* filling the render structure */
 	if (!rndrer)
+		return;
+
+	text = bufnew(TEXT_UNIT);
+	if (!text)
 		return;
 
 	rndr.make = *rndrer;
@@ -2028,7 +2032,7 @@ ups_markdown(struct buf *ob, struct buf *ib, const struct mkd_renderer *rndrer, 
 
 	/* adding a final newline if not already present */
 	if (!text->size)
-		return;
+		goto cleanup;
 
 	if (text->data[text->size - 1] != '\n' &&  text->data[text->size - 1] != '\r')
 		bufputc(text, '\n');
@@ -2043,6 +2047,7 @@ ups_markdown(struct buf *ob, struct buf *ib, const struct mkd_renderer *rndrer, 
 		rndr.make.doc_footer(ob, rndr.make.opaque);
 
 	/* clean-up */
+cleanup:
 	bufrelease(text);
 	lr = rndr.refs.base;
 	for (i = 0; i < (size_t)rndr.refs.size; i += 1) {


### PR DESCRIPTION
ups_markdown() and bufrelease() leak memory. To reproduce:

```
$ touch empty.md
$ LD_LIBRARY_PATH=$PWD valgrind -q --leak-check=full ./upskirt empty.md 
==2707== 40 bytes in 1 blocks are definitely lost in loss record 1 of 2
==2707==    at 0x4C274A8: malloc (vg_replace_malloc.c:236)
==2707==    by 0x4E357F5: bufnew (buffer.c:174)
==2707==    by 0x400F7D: main (upskirt.c:60)
==2707== 
==2707== 40 bytes in 1 blocks are definitely lost in loss record 2 of 2
==2707==    at 0x4C274A8: malloc (vg_replace_malloc.c:236)
==2707==    by 0x4E357F5: bufnew (buffer.c:174)
==2707==    by 0x4E341A4: ups_markdown (markdown.c:1951)
==2707==    by 0x400FCA: main (upskirt.c:66)
==2707==
```

bufreset() has the same bug that bufrelease() has. It's not used according to grep and ctags but I patched it just in case.
