### PR TITLE
Inline bufputc() and bufgrow()

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -23,7 +23,6 @@
  */
 
 #define BUFFER_STDARG
-#define BUFFER_MAX_ALLOC_SIZE (1024 * 1024 * 16) //16mb
 
 #include "buffer.h"
 
@@ -148,25 +147,6 @@ bufdup(const struct buf *src, size_t dupunit) {
 #endif
 	return ret; }
 
-/* bufgrow • increasing the allocated size to the given value */
-int
-bufgrow(struct buf *buf, size_t neosz) {
-	size_t neoasz;
-	void *neodata;
-	if (!buf || !buf->unit || neosz > BUFFER_MAX_ALLOC_SIZE) return 0;
-	if (buf->asize >= neosz) return 1;
-	neoasz = buf->asize + buf->unit;
-	while (neoasz < neosz) neoasz += buf->unit;
-	neodata = realloc(buf->data, neoasz);
-	if (!neodata) return 0;
-#ifdef BUFFER_STATS
-	buffer_stat_alloc_bytes += (neoasz - buf->asize);
-#endif
-	buf->data = neodata;
-	buf->asize = neoasz;
-	return 1; }
-
-
 /* bufnew • allocation of a new buffer */
 struct buf *
 bufnew(size_t unit) {
@@ -214,14 +194,6 @@ bufput(struct buf *buf, const void *data, size_t len) {
 void
 bufputs(struct buf *buf, const char *str) {
 	bufput(buf, str, strlen (str)); }
-
-
-/* bufputc • appends a single char to a buffer */
-void
-bufputc(struct buf *buf, char c) {
-	if (!buf || !bufgrow(buf, buf->size + 1)) return;
-	buf->data[buf->size] = c;
-	buf->size += 1; }
 
 
 /* bufrelease • decrease the reference count and free the buffer if needed */


### PR DESCRIPTION
A disproportionate amount of time is spent in bufputc() and bufgrow(). The pull request inlines them for a pretty big jump in performance. Check it out:

```
 56.64     12.30    12.30 13738889     0.00     0.00  rndr_smartypants
 14.57     15.47     3.17 197493610     0.00     0.00  bufputc
  9.26     17.48     2.01    10969     0.18     1.85  parse_block
  8.75     19.38     1.90 190226522     0.00     0.00  bufgrow
  4.19     20.29     0.91    12384     0.07     1.71  ups_markdown
  1.84     20.69     0.40 13726503     0.00     0.00  char_autolink
  1.52     21.02     0.33    11365     0.03     0.03  rndr_paragraph
```

Before (median of three):

```
$ time ./benchmark
real    0m40.680s
user    1m15.200s
sys     0m0.310s
```

After (idem):

```
$ time ./benchmark
real    0m10.395s
user    0m20.260s
sys     0m0.140s
```

If that isn't low hanging fruit, I don't know what is. :-)
