### PR TITLE
Fix autolink.h include guard

### DIFF
--- a/src/autolink.h
+++ b/src/autolink.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef UPSKIRT_AUTOLINK_H
-#define UPSKIRT_AUTOLINK_H_H
+#define UPSKIRT_AUTOLINK_H
 
 #include "buffer.h"
 


### PR DESCRIPTION
Trivial autoguard typo fix.
