### PR TITLE
Fix segfault doing SAFELINK check on empty links during HTML render.

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -300,7 +300,7 @@ rndr_link(struct buf *ob, struct buf *link, struct buf *title, struct buf *conte
 {
 	struct html_renderopt *options = opaque;
 	
-	if ((options->flags & HTML_SAFELINK) != 0 && !sd_autolink_issafe(link->data, link->size))
+	if (link != NULL && (options->flags & HTML_SAFELINK) != 0 && !sd_autolink_issafe(link->data, link->size))
 		return 0;
 
 	BUFPUTSL(ob, "<a href=\"");


### PR DESCRIPTION
`[Empty]()` from the markdown test suite causes a segfault when checking if the link is safe since `link` is null. 
