### PR TITLE
Use <th> for table header cells.

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -484,29 +484,32 @@ rndr_tablerow(struct buf *ob, struct buf *text, void *opaque)
 }
 
 static void
-rndr_tablecell(struct buf *ob, struct buf *text, int align, void *opaque)
+rndr_tablecell(struct buf *ob, struct buf *text, int flags, void *opaque)
 {
-	switch (align) {
-	case MKD_TABLE_ALIGN_L:
-		BUFPUTSL(ob, "<td align=\"left\">");
-		break;
+	if ((flags & MKD_TABLE_HEADER) == MKD_TABLE_HEADER) {
+		BUFPUTSL(ob, "<th");
+	} else {
+		BUFPUTSL(ob, "<td");
+	}
 
-	case MKD_TABLE_ALIGN_R:
-		BUFPUTSL(ob, "<td align=\"right\">");
-		break;
-
-	case MKD_TABLE_ALIGN_CENTER:
-		BUFPUTSL(ob, "<td align=\"center\">");
-		break;
-
-	default:
-		BUFPUTSL(ob, "<td>");
-		break;
+	if ((flags & MKD_TABLE_ALIGN_CENTER) == MKD_TABLE_ALIGN_CENTER) {
+		BUFPUTSL(ob, " align=\"center\">");
+	} else if ((flags & MKD_TABLE_ALIGN_L) == MKD_TABLE_ALIGN_L) {
+		BUFPUTSL(ob, " align=\"left\">");
+	} else if ((flags & MKD_TABLE_ALIGN_R) == MKD_TABLE_ALIGN_R) {
+		BUFPUTSL(ob, " align=\"right\">");
+	} else {
+		BUFPUTSL(ob, ">");
 	}
 
 	if (text)
 		bufput(ob, text->data, text->size);
-	BUFPUTSL(ob, "</td>\n");
+
+	if (flags & MKD_TABLE_HEADER) {
+		BUFPUTSL(ob, "</th>\n");
+	} else {
+		BUFPUTSL(ob, "</td>\n");
+	}
 }
 
 static int

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -29,6 +29,9 @@
 #define BUFFER_BLOCK 0
 #define BUFFER_SPAN 1
 
+#define TABLE_HEADER 0
+#define TABLE_BODY 1
+
 #define MKD_LI_END 8	/* internal list flag */
 
 /***************
@@ -1800,10 +1803,11 @@ parse_htmlblock(struct buf *ob, struct render *rndr, char *data, size_t size, in
 }
 
 static void
-parse_table_row(struct buf *ob, struct render *rndr, char *data, size_t size, size_t columns, int *col_data)
+parse_table_row(struct buf *ob, struct render *rndr, char *data, size_t size, size_t columns, int *col_data, int row_type)
 {
 	size_t i = 0, col;
 	struct buf *row_work = 0;
+	int base_flags = (row_type) == TABLE_HEADER ? MKD_TABLE_HEADER : 0;
 
 	row_work = rndr_newbuf(rndr, BUFFER_SPAN);
 
@@ -1813,6 +1817,7 @@ parse_table_row(struct buf *ob, struct render *rndr, char *data, size_t size, si
 	for (col = 0; col < columns && i < size; ++col) {
 		size_t cell_start, cell_end;
 		struct buf *cell_work;
+		int flags = base_flags;
 
 		cell_work = rndr_newbuf(rndr, BUFFER_SPAN);
 
@@ -1830,8 +1835,11 @@ parse_table_row(struct buf *ob, struct render *rndr, char *data, size_t size, si
 			cell_end--;
 
 		parse_inline(cell_work, rndr, data + cell_start, 1 + cell_end - cell_start);
-		if (rndr->cb.table_cell)
-			rndr->cb.table_cell(row_work, cell_work, col_data ? col_data[col] : 0, rndr->opaque);
+		if (rndr->cb.table_cell) {
+			if (col_data) {
+				flags |= col_data[col]; }
+			rndr->cb.table_cell(row_work, cell_work, flags, rndr->opaque);
+		}
 
 		rndr_popbuf(rndr, BUFFER_SPAN);
 		i++;
@@ -1839,8 +1847,12 @@ parse_table_row(struct buf *ob, struct render *rndr, char *data, size_t size, si
 
 	for (; col < columns; ++col) {
 		struct buf empty_cell = {0, 0, 0, 0, 0};
-		if (rndr->cb.table_cell)
-			rndr->cb.table_cell(row_work, &empty_cell, col_data ? col_data[col] : 0, rndr->opaque);
+		int flags = base_flags;
+		if (rndr->cb.table_cell) {
+			if (col_data) {
+				flags |= col_data[col]; }
+			rndr->cb.table_cell(row_work, &empty_cell, flags, rndr->opaque);
+		}
 	}
 
 	if (rndr->cb.table_row)
@@ -1918,7 +1930,7 @@ parse_table_header(struct buf *ob, struct render *rndr, char *data, size_t size,
 	if (col < *columns)
 		return 0;
 
-	parse_table_row(ob, rndr, data, header_end, *columns, *column_data);
+	parse_table_row(ob, rndr, data, header_end, *columns, *column_data, TABLE_HEADER);
 	return under_end + 1;
 }
 
@@ -1954,7 +1966,7 @@ parse_table(struct buf *ob, struct render *rndr, char *data, size_t size)
 				break;
 			}
 
-			parse_table_row(body_work, rndr, data + row_start, i - row_start, columns, col_data);
+			parse_table_row(body_work, rndr, data + row_start, i - row_start, columns, col_data, TABLE_BODY);
 			i++;
 		}
 

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -99,6 +99,8 @@ struct sd_callbacks {
 #define MKD_TABLE_ALIGN_R (1 << 1)
 #define MKD_TABLE_ALIGN_CENTER (MKD_TABLE_ALIGN_L | MKD_TABLE_ALIGN_R)
 
+#define MKD_TABLE_HEADER (1 << 2)
+
 /**********************
  * EXPORTED FUNCTIONS *
  **********************/


### PR DESCRIPTION
Table cells in the `<thead>` section should be `<th>`. This patch will do that, but does necessitate changes in downstream renderers.
