### PR TITLE
Entity-escape link hrefs.

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -110,7 +110,7 @@ rndr_autolink(struct buf *ob, struct buf *link, enum mkd_autolink type, void *op
 	BUFPUTSL(ob, "<a href=\"");
 	if (type == MKDA_EMAIL)
 		BUFPUTSL(ob, "mailto:");
-	bufput(ob, link->data, link->size);
+	sdhtml_escape(ob, link->data, link->size);
 
 	if (options->link_attributes) {
 		bufputc(ob, '\"');
@@ -306,7 +306,7 @@ rndr_link(struct buf *ob, struct buf *link, struct buf *title, struct buf *conte
 	BUFPUTSL(ob, "<a href=\"");
 
 	if (link && link->size)
-		bufput(ob, link->data, link->size);
+		sdhtml_escape(ob, link->data, link->size);
 
 	if (title && title->size) {
 		BUFPUTSL(ob, "\" title=\"");


### PR DESCRIPTION
The `href` attribute on links was not being entity-escaped in the HTML renderer. Links with ampersands were getting through, resulting in invalid markup. This adds escaping to regular and automatic link hrefs.

(sorry, not sure if you'd prefer all these pulls separated out like this or merged together; hope you don't feel I'm spamming you :)
