### PR TITLE
Enforcing `const` and a compiler warning

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1771,7 +1771,7 @@ parse_htmlblock(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 	if (size < 2 || data[0] != '<')
 		return 0;
 
-	curtag = find_block_tag(data + 1, size - 1);
+	curtag = find_block_tag((char *)data + 1, size - 1);
 
 	/* handling of special cases */
 	if (!curtag) {

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -517,7 +517,7 @@ parse_emph1(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 static size_t
 parse_emph2(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, uint8_t c)
 {
-	int (*render_method)(struct buf *ob, struct buf *text, void *opaque);
+	int (*render_method)(struct buf *ob, const struct buf *text, void *opaque);
 	size_t i = 0, len;
 	struct buf *work = 0;
 	int r;


### PR DESCRIPTION
Two bug fixes. Thanks for the great library tanoku.
