### PR TITLE
The build was broken; I fixed it. I'm using gcc 4.5.2 on Ubuntu.

### DIFF
--- a/html/houdini_html_e.c
+++ b/html/houdini_html_e.c
@@ -49,7 +49,7 @@ static const char *HTML_ESCAPES[] = {
 void
 houdini_escape_html0(struct buf *ob, const uint8_t *src, size_t size, int secure)
 {
-	size_t  i = 0, org, esc;
+	size_t  i = 0, org, esc = 0;
 
 	bufgrow(ob, ESCAPE_GROW_FACTOR(size));
 


### PR DESCRIPTION
Fixed the following build break:

gcc -c -g -O3 -fPIC -Wall -Werror -Wsign-compare -Isrc -Ihtml    -c -o html/houdini_html_e.o html/houdini_html_e.c
cc1: warnings being treated as errors
html/houdini_html_e.c: In function ‘houdini_escape_html0’:
html/houdini_html_e.c:52:22: error: ‘esc’ may be used uninitialized in this function
make: **\* [html/houdini_html_e.o] Error 1
