### PR TITLE
Nesting lists of different types works again

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1623,8 +1623,10 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 		has_next_oli = prefix_oli(data + beg + i, end - beg - i);
 
 		/* checking for ul/ol switch */
-		if (((*flags & MKD_LIST_ORDERED) && has_next_uli) ||
-			(!(*flags & MKD_LIST_ORDERED) && has_next_oli)) {
+		if (in_empty && (
+					((*flags & MKD_LIST_ORDERED) && has_next_uli) ||
+					(!(*flags & MKD_LIST_ORDERED) && has_next_oli)
+			)){
 			*flags |= MKD_LI_END;
 			break; /* the following item must have same list type */
 		}


### PR DESCRIPTION
Commit 3c32220c7b0b4c35199420e150a9632cee958cc0 broke the ability to nest lists of different types.  
