### PR TITLE
Corrected the way link alt text is handled

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -839,6 +839,7 @@ char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset
 	struct buf *u_link = 0;
 	size_t org_work_size = rndr->work_bufs[BUFFER_SPAN].size;
 	int text_has_nl = 0, ret = 0;
+	int in_title = 0, qtype = 0;
 
 	/* checking whether the correct renderer exists */
 	if ((is_img && !rndr->cb.image) || (!is_img && !rndr->cb.link))
@@ -895,12 +896,15 @@ char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset
 
 		/* looking for title end if present */
 		if (data[i] == '\'' || data[i] == '"') {
+			qtype = data[i];
+			in_title = 1;
 			i++;
 			title_b = i;
 
 			while (i < size) {
 				if (data[i] == '\\') i += 2;
-				else if (data[i] == ')') break;
+				else if (data[i] == qtype) {in_title = 0; i++;}
+				else if ((data[i] == ')') && !in_title) break;
 				else i++;
 			}
 


### PR DESCRIPTION
Brackets would terminate alt-text, such as:

```
  [Link text](http://google.ca "Hello :)")
```

would terminate the alt text early.  Mixing quote types would also work as valid markdown.  This patch changes it so that the termination of an alt text is based off of the same quote as the starting quote.  

See also: https://github.com/reddit/snudown/issues/10
