### PR TITLE
Exclude <style> blocks from replacement

### DIFF
--- a/html/html_smartypants.c
+++ b/html/html_smartypants.c
@@ -264,8 +264,10 @@ smartypants_cb__dquote(struct buf *ob, struct smartypants_data *smrt, uint8_t pr
 static size_t
 smartypants_cb__ltag(struct buf *ob, struct smartypants_data *smrt, uint8_t previous_char, const uint8_t *text, size_t size)
 {
-	static const char *skip_tags[] = {"pre", "code", "kbd", "script", "style"};
-	static const size_t skip_tags_count = 5;
+	static const char *skip_tags[] = {
+	  "pre", "code", "var", "samp", "kbd", "math", "script", "style"
+	};
+	static const size_t skip_tags_count = 8;
 
 	size_t tag, i = 0;
 

--- a/html/html_smartypants.c
+++ b/html/html_smartypants.c
@@ -264,8 +264,8 @@ smartypants_cb__dquote(struct buf *ob, struct smartypants_data *smrt, uint8_t pr
 static size_t
 smartypants_cb__ltag(struct buf *ob, struct smartypants_data *smrt, uint8_t previous_char, const uint8_t *text, size_t size)
 {
-	static const char *skip_tags[] = {"pre", "code", "kbd", "script"};
-	static const size_t skip_tags_count = 4;
+	static const char *skip_tags[] = {"pre", "code", "kbd", "script", "style"};
+	static const size_t skip_tags_count = 5;
 
 	size_t tag, i = 0;
 

--- a/html_block_names.txt
+++ b/html_block_names.txt
@@ -19,6 +19,7 @@ table
 figure
 iframe
 script
+style
 fieldset
 noscript
 blockquote

--- a/src/html_blocks.h
+++ b/src/html_blocks.h
@@ -147,7 +147,7 @@ find_block_tag (str, len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 23,
+      TOTAL_KEYWORDS = 24,
       MIN_WORD_LENGTH = 1,
       MAX_WORD_LENGTH = 10,
       MIN_HASH_VALUE = 1,
@@ -179,7 +179,8 @@ find_block_tag (str, len)
       "script",
       "h5",
       "noscript",
-      "", "",
+      "",
+      "style",
       "iframe",
       "h4",
       "ins",


### PR DESCRIPTION
Like script elements, style elements can contain neither NCRs or entities so they need to be excluded from replacement. Also add `var`, `samp`, and `math` to SmartyPants’ exception list.
