### PR TITLE
Escape HTML in the HTML Renderer

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -605,6 +605,6 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		callbacks->autolink = NULL;
 	}
 
-	if (render_flags & HTML_SKIP_HTML)
+	if (render_flags & HTML_SKIP_HTML || render_flags & HTML_ESCAPE)
 		callbacks->blockhtml = NULL;
 }

--- a/html/html.c
+++ b/html/html.c
@@ -375,6 +375,13 @@ rndr_raw_html(struct buf *ob, const struct buf *text, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
+	/* HTML_ESCAPE overrides SKIP_HTML, SKIP_STYLE, SKIP_LINKS and SKIP_IMAGES
+	* It doens't see if there are any valid tags, just escape all of them. */
+	if((options->flags & HTML_ESCAPE) != 0) {
+		houdini_escape_html(ob, text->data, text->size);
+		return 1;
+	}
+
 	if ((options->flags & HTML_SKIP_HTML) != 0)
 		return 1;
 

--- a/html/html.h
+++ b/html/html.h
@@ -43,6 +43,7 @@ typedef enum {
 	HTML_TOC = (1 << 6),
 	HTML_HARD_WRAP = (1 << 7),
 	HTML_USE_XHTML = (1 << 8),
+	HTML_ESCAPE = (1 << 9),
 } html_render_mode;
 
 typedef enum {


### PR DESCRIPTION
Hi,

I re-applied changes for HTML Escaping option in Sundown, as we discussed in tanoku/redcarpet#84.

Yu-Cheng Chuang
