### PR TITLE
Require a space for link titles

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -888,7 +888,8 @@ char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset
 		/* looking for link end: ' " ) */
 		while (i < size) {
 			if (data[i] == '\\') i += 2;
-			else if (data[i] == ')' || data[i] == '\'' || data[i] == '"') break;
+			else if (data[i] == ')') break;
+			else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}
 


### PR DESCRIPTION
This fixes a bug we were experiencing where links with quotes in them were breaking where they previously were not.  This adds the requirement of a space between the link and the title, as shown in the markdown "spec". 
