### PR TITLE
Escape html inside table of contents.

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -509,7 +509,7 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 
 	bufprintf(ob, "<a href=\"#toc_%d\">", options->toc_data.header_count++);
 	if (text)
-		bufput(ob, text->data, text->size);
+		escape_html(ob, text->data, text->size);
 	BUFPUTSL(ob, "</a>\n");
 }
 


### PR DESCRIPTION
The contents of the table of contents was not being escaped.

Example input:
`# This & That`

Was outputting:

<pre>
&lt;ul&gt;
&lt;li&gt;
&lt;a href=&quot;#toc_0&quot;&gt;This &amp; That&lt;/a&gt;
&lt;/li&gt;
&lt;/ul&gt;
</pre>


Now outputs:

<pre>
&lt;ul&gt;
&lt;li&gt;
&lt;a href=&quot;#toc_0&quot;&gt;This &amp;amp; That&lt;/a&gt;
&lt;/li&gt;
&lt;/ul&gt;
</pre>
