### PR TITLE
Opened parsing flags to external code

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -55,21 +55,21 @@ struct link_ref {
 /*   returns the number of chars taken care of */
 /*   data is the pointer of the beginning of the span */
 /*   offset is the number of valid chars before data */
-struct sd_markdown;
+struct sd_markdown_parser;
 typedef size_t
-(*char_trigger)(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+(*char_trigger)(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
 
-static size_t char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
-static size_t char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_emphasis(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_linebreak(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_codespan(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_escape(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_entity(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_langle_tag(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_autolink_url(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_autolink_email(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_autolink_www(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_link(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
+static size_t char_superscript(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size);
 
 enum markdown_char_t {
 	MD_CHAR_NONE = 0,
@@ -102,8 +102,8 @@ static char_trigger markdown_char_ptrs[] = {
 };
 
 /* render • structure containing one particular render */
-struct sd_markdown {
-	struct sd_parser prsr;
+struct sd_markdown_parser {
+	struct sd_markdown prsr;
 	struct sd_callbacks	cb;
 	void *opaque;
 
@@ -119,7 +119,7 @@ struct sd_markdown {
  ***************************/
 
 static inline struct buf *
-rndr_newbuf(struct sd_markdown *rndr, int type)
+rndr_newbuf(struct sd_markdown_parser *rndr, int type)
 {
 	static const size_t buf_size[2] = {256, 64};
 	struct buf *work = NULL;
@@ -138,7 +138,7 @@ rndr_newbuf(struct sd_markdown *rndr, int type)
 }
 
 static inline void
-rndr_popbuf(struct sd_markdown *rndr, int type)
+rndr_popbuf(struct sd_markdown_parser *rndr, int type)
 {
 	rndr->work_bufs[type].size--;
 }
@@ -346,7 +346,7 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 
 /* parse_inline • parses inline markdown elements */
 static void
-parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_inline(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t i = 0, end = 0;
 	uint8_t action = 0;
@@ -477,7 +477,7 @@ find_emph_char(uint8_t *data, size_t size, uint8_t c)
 /* parse_emph1 • parsing single emphase */
 /* closed by a symbol not preceded by whitespace and not followed by symbol */
 static size_t
-parse_emph1(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, uint8_t c)
+parse_emph1(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, uint8_t c)
 {
 	size_t i = 0, len;
 	struct buf *work = 0;
@@ -514,7 +514,7 @@ parse_emph1(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 /* parse_emph2 • parsing single emphase */
 static size_t
-parse_emph2(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, uint8_t c)
+parse_emph2(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, uint8_t c)
 {
 	int (*render_method)(struct buf *ob, const struct buf *text, void *opaque);
 	size_t i = 0, len;
@@ -546,7 +546,7 @@ parse_emph2(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 /* parse_emph3 • parsing single emphase */
 /* finds the first closing tag, and delegates to the other emph */
 static size_t
-parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, uint8_t c)
+parse_emph3(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, uint8_t c)
 {
 	size_t i = 0, len;
 	int r;
@@ -587,7 +587,7 @@ parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 /* char_emphasis • single and double emphasis parsing */
 static size_t
-char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_emphasis(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	uint8_t c = data[0];
 	size_t ret;
@@ -621,7 +621,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_linebreak • '\n' preceded by two spaces (assuming linebreak != 0) */
 static size_t
-char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_linebreak(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	if (offset < 2 || data[-1] != ' ' || data[-2] != ' ')
 		return 0;
@@ -636,7 +636,7 @@ char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t o
 
 /* char_codespan • '`' parsing a code span (assuming codespan != 0) */
 static size_t
-char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_codespan(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	size_t end, nb = 0, i, f_begin, f_end;
 
@@ -679,7 +679,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 /* char_escape • '\\' backslash escape */
 static size_t
-char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_escape(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>^~";
 	struct buf work = { 0, 0, 0, 0 };
@@ -704,7 +704,7 @@ char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 /* char_entity • '&' escaped when it doesn't belong to an entity */
 /* valid entities are assumed to be anything matching &#?[A-Za-z0-9]+; */
 static size_t
-char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_entity(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	size_t end = 1;
 	struct buf work = { 0, 0, 0, 0 };
@@ -732,7 +732,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 
 /* char_langle_tag • '<' when tags or autolinks are allowed */
 static size_t
-char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_langle_tag(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	enum mkd_autolink altype = MKDA_NOT_AUTOLINK;
 	size_t end = tag_length(data, size, &altype);
@@ -757,7 +757,7 @@ char_langle_tag(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 }
 
 static size_t
-char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_www(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	struct buf *link, *link_url, *link_text;
 	size_t link_len, rewind;
@@ -789,7 +789,7 @@ char_autolink_www(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 }
 
 static size_t
-char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_email(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -809,7 +809,7 @@ char_autolink_email(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, siz
 }
 
 static size_t
-char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_autolink_url(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	struct buf *link;
 	size_t link_len, rewind;
@@ -830,7 +830,7 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 /* char_link • '[': parsing a link or an image */
 static size_t
-char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_link(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	int is_img = (offset && data[-1] == '!'), level;
 	size_t i = 1, txt_e, link_b = 0, link_e = 0, title_b = 0, title_e = 0;
@@ -1065,7 +1065,7 @@ cleanup:
 }
 
 static size_t
-char_superscript(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
+char_superscript(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t offset, size_t size)
 {
 	size_t sup_start, sup_len;
 	struct buf *sup;
@@ -1226,7 +1226,7 @@ is_codefence(uint8_t *data, size_t size, struct buf *syntax)
 
 /* is_atxheader • returns whether the line is a hash-prefixed header */
 static int
-is_atxheader(struct sd_markdown *rndr, uint8_t *data, size_t size)
+is_atxheader(struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	if (data[0] != '#')
 		return 0;
@@ -1356,13 +1356,13 @@ prefix_uli(uint8_t *data, size_t size)
 
 
 /* parse_block • parsing of one block, returning next uint8_t to parse */
-static void parse_block(struct buf *ob, struct sd_markdown *rndr,
+static void parse_block(struct buf *ob, struct sd_markdown_parser *rndr,
 			uint8_t *data, size_t size);
 
 
 /* parse_blockquote • handles parsing of a blockquote fragment */
 static size_t
-parse_blockquote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_blockquote(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t beg, end = 0, pre, work_size = 0;
 	uint8_t *work_data = 0;
@@ -1403,11 +1403,11 @@ parse_blockquote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 }
 
 static size_t
-parse_htmlblock(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int do_render);
+parse_htmlblock(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, int do_render);
 
 /* parse_blockquote • handles parsing of a regular paragraph */
 static size_t
-parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_paragraph(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t i = 0, end = 0;
 	int level = 0;
@@ -1487,7 +1487,7 @@ parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 
 /* parse_fencedcode • handles parsing of a block-level code fragment */
 static size_t
-parse_fencedcode(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_fencedcode(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t beg, end;
 	struct buf *work = 0;
@@ -1530,7 +1530,7 @@ parse_fencedcode(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 }
 
 static size_t
-parse_blockcode(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_blockcode(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t beg, end, pre;
 	struct buf *work = 0;
@@ -1573,7 +1573,7 @@ parse_blockcode(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 /* parse_listitem • parsing of a single list item */
 /*	assuming initial prefix is already removed */
 static size_t
-parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int *flags)
+parse_listitem(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, int *flags)
 {
 	struct buf *work = 0, *inter = 0;
 	size_t beg = 0, end, pre, sublist = 0, orgpre = 0, i;
@@ -1698,7 +1698,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 
 /* parse_list • parsing ordered or unordered list block */
 static size_t
-parse_list(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int flags)
+parse_list(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, int flags)
 {
 	struct buf *work = 0;
 	size_t i = 0, j;
@@ -1721,7 +1721,7 @@ parse_list(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size,
 
 /* parse_atxheader • parsing of atx-style headers */
 static size_t
-parse_atxheader(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_atxheader(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t level = 0;
 	size_t i, end, skip;
@@ -1758,7 +1758,7 @@ parse_atxheader(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 /* htmlblock_end • checking end of HTML block : </tag>[ \t]*\n[ \t*]\n */
 /*	returns the length on match, 0 otherwise */
 static size_t
-htmlblock_end(const char *tag, size_t tag_len, struct sd_markdown *rndr, uint8_t *data, size_t size)
+htmlblock_end(const char *tag, size_t tag_len, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t i, w;
 
@@ -1790,7 +1790,7 @@ htmlblock_end(const char *tag, size_t tag_len, struct sd_markdown *rndr, uint8_t
 
 /* parse_htmlblock • parsing of inline HTML block */
 static size_t
-parse_htmlblock(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int do_render)
+parse_htmlblock(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size, int do_render)
 {
 	size_t i, j = 0;
 	const char *curtag = NULL;
@@ -1894,7 +1894,7 @@ parse_htmlblock(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 static void
 parse_table_row(
 	struct buf *ob,
-	struct sd_markdown *rndr,
+	struct sd_markdown_parser *rndr,
 	uint8_t *data,
 	size_t size,
 	size_t columns,
@@ -1951,7 +1951,7 @@ parse_table_row(
 static size_t
 parse_table_header(
 	struct buf *ob,
-	struct sd_markdown *rndr,
+	struct sd_markdown_parser *rndr,
 	uint8_t *data,
 	size_t size,
 	size_t *columns,
@@ -2040,7 +2040,7 @@ parse_table_header(
 static size_t
 parse_table(
 	struct buf *ob,
-	struct sd_markdown *rndr,
+	struct sd_markdown_parser *rndr,
 	uint8_t *data,
 	size_t size)
 {
@@ -2097,7 +2097,7 @@ parse_table(
 
 /* parse_block • parsing of one block, returning next uint8_t to parse */
 static void
-parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
+parse_block(struct buf *ob, struct sd_markdown_parser *rndr, uint8_t *data, size_t size)
 {
 	size_t beg, end, i;
 	uint8_t *txt_data;
@@ -2305,18 +2305,18 @@ static void expand_tabs(struct buf *ob, const uint8_t *line, size_t size)
  * EXPORTED FUNCTIONS *
  **********************/
 
-struct sd_parser *
-sd_markdown_new(
+struct sd_markdown *
+sd_markdown_parser_new(
 	unsigned int extensions,
 	size_t max_nesting,
 	const struct sd_callbacks *callbacks,
 	void *opaque)
 {
-	struct sd_markdown *md = NULL;
+	struct sd_markdown_parser *md = NULL;
 
 	assert(max_nesting > 0 && callbacks);
 
-	md = malloc(sizeof(struct sd_markdown));
+	md = malloc(sizeof(struct sd_markdown_parser));
 	if (!md)
 		return NULL;
 
@@ -2362,16 +2362,16 @@ sd_markdown_new(
 	md->max_nesting = max_nesting;
 	md->prsr.in_link_body = 0;
 
-	return (struct sd_parser *)md;
+	return (struct sd_markdown *)md;
 }
 
 void
-sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_parser *p)
+sd_markdown_parser_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_markdown *p)
 {
 #define MARKDOWN_GROW(x) ((x) + ((x) >> 1))
 	static const char UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 
-	struct sd_markdown *md = (struct sd_markdown *)p;
+	struct sd_markdown_parser *md = (struct sd_markdown_parser *)p;
 	struct buf *text;
 	size_t beg, end;
 
@@ -2442,10 +2442,10 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 }
 
 void
-sd_markdown_free(struct sd_parser *p)
+sd_markdown_parser_free(struct sd_markdown *p)
 {
 	size_t i;
-	struct sd_markdown *md = (struct sd_markdown *)p;
+	struct sd_markdown_parser *md = (struct sd_markdown_parser *)p;
 
 	for (i = 0; i < (size_t)md->work_bufs[BUFFER_SPAN].asize; ++i)
 		bufrelease(md->work_bufs[BUFFER_SPAN].item[i]);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -95,7 +95,9 @@ struct sd_callbacks {
 	void (*doc_footer)(struct buf *ob, void *opaque);
 };
 
-struct sd_markdown;
+struct sd_parser {
+	int in_link_body;
+};
 
 /*********
  * FLAGS *
@@ -109,7 +111,7 @@ struct sd_markdown;
  * EXPORTED FUNCTIONS *
  **********************/
 
-extern struct sd_markdown *
+extern struct sd_parser *
 sd_markdown_new(
 	unsigned int extensions,
 	size_t max_nesting,
@@ -117,10 +119,10 @@ sd_markdown_new(
 	void *opaque);
 
 extern void
-sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_markdown *md);
+sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_parser *md);
 
 extern void
-sd_markdown_free(struct sd_markdown *md);
+sd_markdown_free(struct sd_parser *md);
 
 extern void
 sd_version(int *major, int *minor, int *revision);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -95,7 +95,7 @@ struct sd_callbacks {
 	void (*doc_footer)(struct buf *ob, void *opaque);
 };
 
-struct sd_parser {
+struct sd_markdown {
 	int in_link_body;
 };
 
@@ -111,18 +111,18 @@ struct sd_parser {
  * EXPORTED FUNCTIONS *
  **********************/
 
-extern struct sd_parser *
-sd_markdown_new(
+extern struct sd_markdown *
+sd_markdown_parser_new(
 	unsigned int extensions,
 	size_t max_nesting,
 	const struct sd_callbacks *callbacks,
 	void *opaque);
 
 extern void
-sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_parser *md);
+sd_markdown_parser_render(struct buf *ob, const uint8_t *document, size_t doc_size, struct sd_markdown *md);
 
 extern void
-sd_markdown_free(struct sd_parser *md);
+sd_markdown_parser_free(struct sd_markdown *md);
 
 extern void
 sd_version(int *major, int *minor, int *revision);


### PR DESCRIPTION
I'm investigating replacement for Discount in my project ([appledoc](http://github.com/tomaz/appledoc)). Sundown seems like a way to go. Although I could use included html renderer out of the box, I need to preprocess Markdown before that (for detecting cross references for example).

For that to work, I need to do processing inside `normal_text` callback, however I need to work differently whether the text is inside a link or not and the simplest way I found it to work was to open up parsing flags to outside code - basically, I'd assign pointer to `sd_markdown` to my renderer opaque struct and check the flags in callbacks. One way would be to make whole `sd_markdown` public, but I didn't like that - so basically I refactored it into public/private interface.

To prevent breaking existing users code, I renamed what was before `sd_markdown` into `sd_markdown_parser` - this is used internally. And then I simply updated the public interface `sd_markdown` to include relevant flags. `sd_markdown_parser` includes `sd_markdown` struct as the first var - hence I can look at pointers to both structs either way. At this point the only flag included is `in_link_body`, but that can be extended in the future should the need be. So my code looks like this:

```
struct html_renderopt {
    ...
    struct sd_markdown *markdown;
    ...
};
```

```
int main() {
    ...
    sdhtml_renderer(&callbacks, &options, extensions);
    markdown = sd_markdown_parser_new(extensions, 16, &callbacks, &options);
    options.markdown = markdown;
    ...
}
```

```
static void
rndr_normal_text(struct buf *ob, const struct buf *text, void *opaque)
{
    if (text) {
        struct html_renderopt *options = (struct html_renderopt *)opaque;
        if (options->markdown->in_link_body == 1) { /* do whatever needed if in link */ }
        escape_html(ob, text->data, text->size);
    }
}
```

Hopefully you'll find additions useful and merge them to main branch - I'd love to be able to use future updates to main branch without the hassle of refactoring above changes every time :) But feel free to close pull request if you find changes not suitable for your audience.
