### PR TITLE
Fix for building with Visual Studio

### DIFF
--- a/html/html_smartypants.c
+++ b/html/html_smartypants.c
@@ -22,6 +22,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_WIN32)
+#define snprintf	_snprintf		
+#endif
+
 struct smartypants_data {
 	int in_squote;
 	int in_dquote;

--- a/src/autolink.c
+++ b/src/autolink.c
@@ -21,6 +21,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#if defined(_WIN32)
+#define strncasecmp	_strnicmp
+#endif
+
 int
 sd_autolink_issafe(const uint8_t *link, size_t link_len)
 {

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -25,6 +25,10 @@
 #include <ctype.h>
 #include <stdio.h>
 
+#if defined(_WIN32)
+#define strncasecmp	_strnicmp
+#endif
+
 #define REF_TABLE_SIZE 8
 
 #define BUFFER_BLOCK 0


### PR DESCRIPTION
I know that two other pull request also handle this issue, but I believe that this is the smallest/cleanest way to handle the portability.

Correct the following link errors:
markdown.obj : error LNK2019: unresolved external symbol _strncasecmp referenced in function _find_block_tag
autolink.obj : error LNK2001: unresolved external symbol _strncasecmp
html_smartypants.obj : error LNK2019: unresolved external symbol _snprintf referenced in function _smartypants_quotes

I needed to add 1 define in 3 files, betweend #if defined(_WIN32) guards :
- #define strncasecmp _strnicmp
- #define snprintf _snprintf

Thank you,
Srombauts
