### PR TITLE
Do not nest the fist list in a table of contents.

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -491,6 +491,11 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
+	if (options->toc_data.header_count == 0) {
+		options->toc_data.level_offset = level - 1;
+	}
+	level -= options->toc_data.level_offset;
+
 	if (level > options->toc_data.current_level) {
 		while (level > options->toc_data.current_level) {
 			BUFPUTSL(ob, "<ul>\n<li>\n");
@@ -516,7 +521,7 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 static int
 toc_link(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *content, void *opaque)
 {
-	if (content && content->size) 
+	if (content && content->size)
 		bufput(ob, content->data, content->size);
 	return 1;
 }

--- a/html/html.h
+++ b/html/html.h
@@ -25,6 +25,7 @@ struct html_renderopt {
 	struct {
 		int header_count;
 		int current_level;
+		int level_offset;
 	} toc_data;
 
 	unsigned int flags;


### PR DESCRIPTION
If the first header of a document is a level three header the first list
is nested two times. To prevent this an offset if set when the first
header is found and after that the level is changed to (level - offset).

![Example](http://i.imgur.com/s7CuF.png)
