### PR TITLE
Reset level offset when a new document is rendered

### DIFF
--- a/html/html.c
+++ b/html/html.c
@@ -491,7 +491,7 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
-	if (options->toc_data.header_count == 0) {
+	if (options->toc_data.current_level == 0) {
 		options->toc_data.level_offset = level - 1;
 	}
 	level -= options->toc_data.level_offset;


### PR DESCRIPTION
When you parse multiple documents with the same renderer instance,
`toc_data.level_offset` is only set at the first document, because
`toc_data.header_count` is only `0` once, at the first document.

To fix this `if (options->toc_data.header_count == 0)` must be changed to
`if (options->toc_data.current_level == 0)`, because  `toc_data.current_level`
is `0` at the start of each document. And `toc_data.level_offset` will be
set to the right offset at each document.

Fixes a bug in my previous pull request that is already closed.
