### PR TITLE
add extern C declarations when using c++ compiler

### DIFF
--- a/html/houdini.h
+++ b/html/houdini.h
@@ -3,6 +3,10 @@
 
 #include "buffer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef HOUDINI_USE_LOCALE
 #	define _isxdigit(c) isxdigit(c)
 #	define _isdigit(c) isdigit(c)
@@ -25,5 +29,9 @@ extern void houdini_unescape_uri(struct buf *ob, const uint8_t *src, size_t size
 extern void houdini_unescape_url(struct buf *ob, const uint8_t *src, size_t size);
 extern void houdini_escape_js(struct buf *ob, const uint8_t *src, size_t size);
 extern void houdini_unescape_js(struct buf *ob, const uint8_t *src, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/html/html.h
+++ b/html/html.h
@@ -21,6 +21,10 @@
 #include "buffer.h"
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct html_renderopt {
 	struct {
 		int header_count;
@@ -64,6 +68,10 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 
 extern void
 sdhtml_smartypants(struct buf *ob, const uint8_t *text, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/autolink.h
+++ b/src/autolink.h
@@ -19,6 +19,10 @@
 
 #include "buffer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int
 sd_autolink_issafe(const uint8_t *link, size_t link_len);
 
@@ -30,6 +34,10 @@ sd_autolink__email(size_t *rewind_p, struct buf *link, uint8_t *data, size_t off
 
 extern size_t
 sd_autolink__url(size_t *rewind_p, struct buf *link, uint8_t *data, size_t offset, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -22,6 +22,10 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(_MSC_VER)
 #define __attribute__(x)
 #define inline
@@ -84,5 +88,9 @@ void bufslurp(struct buf *, size_t);
 
 /* bufprintf: formatted printing to a buffer */
 void bufprintf(struct buf *, const char *, ...) __attribute__ ((format (printf, 2, 3)));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -22,6 +22,10 @@
 #include "buffer.h"
 #include "autolink.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UPSKIRT_VERSION "1.15.2"
 #define UPSKIRT_VER_MAJOR 1
 #define UPSKIRT_VER_MINOR 15
@@ -124,6 +128,10 @@ sd_markdown_free(struct sd_markdown *md);
 
 extern void
 sd_version(int *major, int *minor, int *revision);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 

--- a/src/stack.h
+++ b/src/stack.h
@@ -3,6 +3,10 @@
 
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct stack {
 	void **item;
 	size_t size;
@@ -17,5 +21,9 @@ int stack_push(struct stack *, void *);
 
 void *stack_pop(struct stack *);
 void *stack_top(struct stack *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/tools/merge-upstream
+++ b/tools/merge-upstream
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git checkout master
+git fetch upstream
+git merge upstream/master
+ 

--- a/tools/sync-to
+++ b/tools/sync-to
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+# verify arguments
+INCLUDE_DIR=$1
+if [ -z "$INCLUDE_DIR" ] || [ ! -d "$INCLUDE_DIR" ]
+then
+   echo "Usage: sync-to <include-dir> <src-dir>"
+   exit 1
+fi
+
+SOURCE_DIR=$2
+if [ -z "$INCLUDE_DIR" ] || [ ! -d "$SOURCE_DIR" ]
+then
+   echo "Usage: sync-to <include-dir> <src-dir>"
+   exit 1
+fi
+
+# checkout master and get version
+git checkout master
+git pull
+VERSION=`git rev-parse HEAD`
+
+# write version file
+echo "#define RSTUDIO_SUNDOWN_VERSION $VERSION" > $SOURCE_DIR/sundown_version.h
+
+# copy files
+SUNDOWN_DIR=`git rev-parse --show-toplevel`
+cp $SUNDOWN_DIR/src/autolink.h $INCLUDE_DIR
+cp $SUNDOWN_DIR/src/buffer.h $INCLUDE_DIR
+cp $SUNDOWN_DIR/src/markdown.h $INCLUDE_DIR
+cp $SUNDOWN_DIR/src/*.h $SOURCE_DIR
+cp $SUNDOWN_DIR/src/*.c $SOURCE_DIR
+cp $SUNDOWN_DIR/html/*.h $SOURCE_DIR
+cp $SUNDOWN_DIR/html/*.c $SOURCE_DIR
+
+
+
+

--- a/tools/sync-to-markdown-package
+++ b/tools/sync-to-markdown-package
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# verify arguments
+MARKDOWN_DIR=$1
+if [ -z "$MARKDOWN_DIR" ] || [ ! -d "$MARKDOWN_DIR" ]
+then
+   echo "Usage: sync-to-markdown-package <package-dir>"
+   exit 1
+fi
+
+# sync to markdown package
+./sync-to $MARKDOWN_DIR/inst/include $MARKDOWN_DIR/src
+

--- a/tools/sync-to-rstudio
+++ b/tools/sync-to-rstudio
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# verify arguments
+RSTUDIO_DIR=$1
+if [ -z "$RSTUDIO_DIR" ] || [ ! -d "$RSTUDIO_DIR" ]
+then
+   echo "Usage: sync-to-rstudio <rstudio-dir>"
+   exit 1
+fi
+
+# sync to rstudio 
+RSTUDIO_SUNDOWN=$RSTUDIO_DIR/src/cpp/core/markdown/sundown
+./sync-to $RSTUDIO_SUNDOWN $RSTUDIO_SUNDOWN
+
+
+


### PR DESCRIPTION
Conditionally added extern "C" block around declarations in header files (this only occurs when building with a c++ compiler). Without this it's inconvenient (but not impossible) to embed sundown in a C++ program. See here for additional discussion: http://www.parashift.com/c++-faq-lite/mixing-c-and-cpp.html#faq-32.4
