### PR TITLE
Add nmake build target for windows.

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,33 @@
+
+CFLAGS=/O2 /EHsc /I"src/" /I"examples"/ /I"html"/
+CC=cl
+
+SUNDOWN_SRC=\
+	src\markdown.obj \
+	src\stack.obj \
+	src\buffer.obj \
+	src\autolink.obj \
+	html\html.obj \
+	html\html_smartypants.obj \
+	html\houdini_html_e.obj \
+	html\houdini_href_e.obj
+
+all: sundown.dll sundown.exe
+
+sundown.dll: $(SUNDOWN_SRC) sundown.def
+	$(CC) $(SUNDOWN_SRC) sundown.def /link /DLL $(LDFLAGS) /out:$@
+
+sundown.exe: examples\sundown.obj $(SUNDOWN_SRC)
+	$(CC) examples\sundown.obj $(SUNDOWN_SRC) /link $(LDFLAGS) /out:$@
+
+# housekeeping
+clean:
+	del $(SUNDOWN_SRC)
+	del sundown.dll sundown.exe
+	del sundown.exp sundown.lib
+
+# generic object compilations
+
+.c.obj:
+	$(CC) $(CFLAGS) /c $< /Fo$@
+

--- a/sundown.def
+++ b/sundown.def
@@ -1,0 +1,20 @@
+LIBRARY SUNDOWN
+EXPORTS
+	sdhtml_renderer
+	sdhtml_toc_renderer
+	sdhtml_smartypants
+	bufgrow
+	bufnew
+	bufcstr
+	bufprefix
+	bufput 
+	bufputs
+	bufputc
+	bufrelease
+	bufreset
+	bufslurp
+	bufprintf
+	sd_markdown_new
+	sd_markdown_render
+	sd_markdown_free
+	sd_version


### PR DESCRIPTION
One can now use nmake like that: nmake /F Makefile.win
to build sundown.exe and sundown.dll easily on windows.

I had to add the MD_EXTERN define to expose the functions in the dll.
Tanoku I would like to hear some comments.
