### PR TITLE
Support the HTML5 Video tag as an Extension

### DIFF
--- a/src/markdown.h
+++ b/src/markdown.h
@@ -83,6 +83,7 @@ struct sd_callbacks {
 	int (*double_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*emphasis)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*image)(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *alt, void *opaque);
+	int (*video)(struct buf *ob, const struct buf **links, const int link_count, const struct buf *alt, const struct buf* poster, void *opaque);
 	int (*linebreak)(struct buf *ob, void *opaque);
 	int (*link)(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *content, void *opaque);
 	int (*raw_html_tag)(struct buf *ob, const struct buf *tag, void *opaque);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -59,6 +59,7 @@ enum mkd_extensions {
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_VIDEO_TAG = (1 << 9),
 };
 
 /* sd_callbacks - functions for rendering parsed data */


### PR DESCRIPTION
Now that the HTML5 Video tag is evolved to the point where it's reasonable to use, it'd be more awesome if we could be embedding screencasts / product demos / whatever in Markdown content.

To do this, I've started implementing an extension to Markdown to support the video tag. I'm proposing the following syntax, which is completely up for debate / changeable: 

```
!![Alt Text](/path/to/video1.mp4,/path/to/video2.webm /path/to/poster.jpg)
```

The main difference is the ability to specify more than one URL, corresponding to the multiple <source> URLs in the <video> tag, since patents have made the Video tag more annoying, as well as the ability to specify the Poster URL (the image that gets shown before the user clicks Play).

```
TODO:

[X] - Add a new callback for video
[X] - Implement a renderer for the callback
[ ] - Add a new parse function to parse the video tag
```
