### PR TITLE
add '$' to list of escapable characters

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -685,7 +685,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 static size_t
 char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
 {
-	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>^~";
+	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>^~$";
 	struct buf work = { 0, 0, 0, 0 };
 
 	if (size > 1) {


### PR DESCRIPTION
Our markdown environment supports the inclusion of latex equations using $...$ syntax. This creates the need for users to be able to escape $ characters. Certainly understand if you don't want to take this if it changes the semantics of existing documents (e.g. \$ will now render as '$' rather than '\$'). If you don't want to take this as-is we could also make it a markdown extension. Of course also happy to just maintain this change on our branch.
