### PR TITLE
Feature outline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ libsundown.so:	libsundown.so.1
 	ln -f -s $^ $@
 
 libsundown.so.1: $(SUNDOWN_SRC)
-	$(CC) $(LDFLAGS) -shared -Wl $^ -o $@
+	$(CC) $(LDFLAGS) -shared $^ -o $@
 
 # executables
 

--- a/html/html.c
+++ b/html/html.c
@@ -170,6 +170,18 @@ rndr_codespan(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static int
+rndr_ins(struct buf *ob, const struct buf *text, void *opaque)
+{
+	if (!text || !text->size)
+		return 0;
+
+	BUFPUTSL(ob, "<ins>");
+	bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "</ins>");
+	return 1;
+}
+
+static int
 rndr_strikethrough(struct buf *ob, const struct buf *text, void *opaque)
 {
 	if (!text || !text->size)
@@ -564,6 +576,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		toc_link,
 		NULL,
 		rndr_triple_emphasis,
+		rndr_ins,
 		rndr_strikethrough,
 		rndr_superscript,
 
@@ -605,6 +618,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		rndr_link,
 		rndr_raw_html,
 		rndr_triple_emphasis,
+		rndr_ins,
 		rndr_strikethrough,
 		rndr_superscript,
 

--- a/html/html.c
+++ b/html/html.c
@@ -233,14 +233,14 @@ rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 	if (ob->size)
 		bufputc(ob, '\n');
         
-        if(options->section_level == level)
+        if(options->outline_data.current_level == level)
         {
             BUFPUTSL(ob, "</section>");
-            options->open_sections--;
+            options->outline_data.open_section_count--;
         }
         BUFPUTSL(ob, "<section>");
-        options->open_sections++;
-        options->section_level = level;
+        options->outline_data.open_section_count++;
+        options->outline_data.current_level = level;
 
 	if (options->flags & HTML_TOC)
 		bufprintf(ob, "<h%d id=\"toc_%d\">", level, options->toc_data.header_count++);
@@ -514,7 +514,7 @@ rndr_finalize(struct buf *ob, void *opaque)
         struct html_renderopt *options = opaque;
         int i;
         
-        for(i = 0; i < options->open_sections; i++)
+        for(i = 0; i < options->outline_data.open_section_count; i++)
         {
             BUFPUTSL(ob, "\n</section>\n");
         }
@@ -655,8 +655,8 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 	/* Prepare the options pointer */
 	memset(options, 0x0, sizeof(struct html_renderopt));
 	options->flags = render_flags;
-        options->open_sections = 0;
-        options->section_level = 0;
+        options->outline_data.open_section_count = 0;
+        options->outline_data.current_level = 0;
 
 	/* Prepare the callbacks */
 	memcpy(callbacks, &cb_default, sizeof(struct sd_callbacks));

--- a/html/html.c
+++ b/html/html.c
@@ -235,7 +235,7 @@ rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
         
     if (options->flags & HTML_OUTLINE) 
     {
-        if(options->outline_data.current_level == level)
+        if(options->outline_data.current_level >= level)
         {
             BUFPUTSL(ob, "</section>");
             options->outline_data.open_section_count--;

--- a/html/html.c
+++ b/html/html.c
@@ -240,7 +240,7 @@ rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
             BUFPUTSL(ob, "</section>");
             options->outline_data.open_section_count--;
         }
-        BUFPUTSL(ob, "<section>");
+        bufprintf(ob, "<section class=\"section%d\">\n", level);
         options->outline_data.open_section_count++;
         options->outline_data.current_level = level;
     }

--- a/html/html.h
+++ b/html/html.h
@@ -54,6 +54,7 @@ typedef enum {
 	HTML_HARD_WRAP = (1 << 7),
 	HTML_USE_XHTML = (1 << 8),
 	HTML_ESCAPE = (1 << 9),
+	HTML_OUTLINE = (1 << 10),
 } html_render_mode;
 
 typedef enum {

--- a/html/html.h
+++ b/html/html.h
@@ -33,6 +33,8 @@ struct html_renderopt {
 	} toc_data;
 
 	unsigned int flags;
+        int section_level;
+        int open_sections;
 
 	/* extra callbacks */
 	void (*link_attributes)(struct buf *ob, const struct buf *url, void *self);

--- a/html/html.h
+++ b/html/html.h
@@ -33,8 +33,11 @@ struct html_renderopt {
 	} toc_data;
 
 	unsigned int flags;
-        int section_level;
-        int open_sections;
+
+    struct {
+        int current_level;
+        int open_section_count;
+    } outline_data;
 
 	/* extra callbacks */
 	void (*link_attributes)(struct buf *ob, const struct buf *url, void *self);

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -526,6 +526,7 @@ parse_emph2(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 	int r;
 
 	render_method = (c == '~') ? rndr->cb.strikethrough : rndr->cb.double_emphasis;
+	render_method = (c == '+') ? rndr->cb.ins : render_method;
 
 	if (!render_method)
 		return 0;
@@ -598,8 +599,9 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 
 	if (size > 2 && data[1] != c) {
 		/* whitespace cannot follow an opening emphasis;
+		 * ins only takes two characters '++'
 		 * strikethrough only takes two characters '~~' */
-		if (c == '~' || _isspace(data[1]) || (ret = parse_emph1(ob, rndr, data + 1, size - 1, c)) == 0)
+		if (c == '+' || c == '~' || _isspace(data[1]) || (ret = parse_emph1(ob, rndr, data + 1, size - 1, c)) == 0)
 			return 0;
 
 		return ret + 1;
@@ -613,7 +615,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 	}
 
 	if (size > 4 && data[1] == c && data[2] == c && data[3] != c) {
-		if (c == '~' || _isspace(data[3]) || (ret = parse_emph3(ob, rndr, data + 3, size - 3, c)) == 0)
+		if (c == '+' || c == '~' || _isspace(data[3]) || (ret = parse_emph3(ob, rndr, data + 3, size - 3, c)) == 0)
 			return 0;
 
 		return ret + 3;
@@ -2415,6 +2417,8 @@ sd_markdown_new(
 		md->active_char['_'] = MD_CHAR_EMPHASIS;
 		if (extensions & MKDEXT_STRIKETHROUGH)
 			md->active_char['~'] = MD_CHAR_EMPHASIS;
+		if (extensions & MKDEXT_INS)
+			md->active_char['+'] = MD_CHAR_EMPHASIS;
 	}
 
 	if (md->cb.codespan)

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2519,6 +2519,9 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 	if (md->cb.doc_footer)
 		md->cb.doc_footer(ob, md->opaque);
 
+	if (md->cb.outline)
+		md->cb.outline(ob, md->opaque);
+
 	/* clean-up */
 	bufrelease(text);
 	free_link_refs(md->refs);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -56,6 +56,7 @@ enum mkd_extensions {
 	MKDEXT_FENCED_CODE = (1 << 2),
 	MKDEXT_AUTOLINK = (1 << 3),
 	MKDEXT_STRIKETHROUGH = (1 << 4),
+	MKDEXT_INS = (1 << 5),
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
@@ -87,6 +88,7 @@ struct sd_callbacks {
 	int (*link)(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *content, void *opaque);
 	int (*raw_html_tag)(struct buf *ob, const struct buf *tag, void *opaque);
 	int (*triple_emphasis)(struct buf *ob, const struct buf *text, void *opaque);
+	int (*ins)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*strikethrough)(struct buf *ob, const struct buf *text, void *opaque);
 	int (*superscript)(struct buf *ob, const struct buf *text, void *opaque);
 

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -99,6 +99,9 @@ struct sd_callbacks {
 	/* header and footer */
 	void (*doc_header)(struct buf *ob, void *opaque);
 	void (*doc_footer)(struct buf *ob, void *opaque);
+
+    /* outliner */
+    void (*outline)(struct buf *ob, void *opaque);
 };
 
 struct sd_markdown;


### PR DESCRIPTION
Hi, I have ported the python-markdown outline extension. Here is what it does:

Wraps the document logical sections (as implied by h1-h6 headings).

By default, the wrapper element is a section tag having a class attribute "sectionN", where N is the header level being wrapped.

More information here:

https://github.com/aleray/mdx_outline
