### PR TITLE
Removed useless linking flag -Wl as gcc 4.7.0+ complains about it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ libsundown.so:	libsundown.so.1
 	ln -f -s $^ $@
 
 libsundown.so.1: $(SUNDOWN_SRC)
-	$(CC) $(LDFLAGS) -shared -Wl $^ -o $@
+	$(CC) $(LDFLAGS) -shared $^ -o $@
 
 # executables
 


### PR DESCRIPTION
using gcc, the -Wl parameter during linking allows you to pass options to the linker directly.  With no comma following the -Wl it does nothing, which is fine until gcc started complaining that it was there, and empty, when linking.
