### PR TITLE
Add support for shebang style code blocks.

### DIFF
--- a/src/markdown.h
+++ b/src/markdown.h
@@ -59,6 +59,7 @@ enum mkd_extensions {
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_SHEBANG_CODE = (1 << 9),
 };
 
 /* sd_callbacks - functions for rendering parsed data */


### PR DESCRIPTION
If the MKDEXT_SHEBANG_CODE  flag is enabled, a block like this:

```
#!ruby
puts "hello world"
```

Is stripped of the shebang line, and the language is treated the same as with a fenced code block.

This was born out of a discussion on Twitter, where I was whining about the fact that syntax highlighting on @github requires the use of fenced code blocks. I hate fenced code blocks, so I wanted an equivalent syntax for indented code blocks. After a brief discussion with @ryanb, @searls, @tpope and a few others, we all felt that this syntax was the nicest.

Does this project have any tests? I couldn't find any. If so, I'd be happy to add tests for this functionality. I used [this file](https://gist.github.com/4119268) as test input. Attached at the link is also output with the flag enabled and disabled.

I tried to be as conservative as possible in what is allowed as a shebang line. I'm total C newb though, so I have no idea if I've missed anything important.
