### PR TITLE
Sundown status, and Hoedown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,13 @@
-﻿Sundown
+﻿**2012-11-09: Sundown is deprecated and no longer under development.**
+
+You may use [Hoedown](https://github.com/hoedown/hoedown) instead, which is
+a continuation of this project and incorporates many improvements and features,
+a better API and documentation.
+
+----
+----
+
+Sundown
 =======
 
 `Sundown` is a Markdown parser based on the original code of the


### PR DESCRIPTION
This simply adds a warning at the top of the `README`
to indicate that Sundown is now frozen, and people should
head to other forks like [**Hoedown**](https://github.com/hoedown/hoedown) to suggest features.

---
#### Background

Sundown has been frozen for a year now, since @vmg announced it was deprecated.

So in _the_ commit (yes, I'm looking at 37728fb2d7137ff7c37d0a474cb827a8d6d846d8) the community (especially @devinus) managed to develop a serious fork, which we decided to call Hoedown.

We took Sundown, simplified the directory structure, made its API consistent, prefixing everything (including enums), merged some popular community-contributed features like [footnotes](https://github.com/vmg/sundown/pull/141) and corrected some bugs, among other things.

And Hoedown (finally) has its first release. If you're curious, here's the [changes we have made to Sundown](https://github.com/hoedown/hoedown/compare) by now.

Now we plan to document Hoedown's API and analyze the code, as well as migrating the bindings to use it.
