### PR TITLE
Fix list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CC=gcc
 SUNDOWN_SRC=\
 	src/markdown.o \
 	src/stack.o \
+	src/src_map.o \
 	src/buffer.o \
 	src/autolink.o \
 	html/html.o \
@@ -44,7 +45,7 @@ libsundown.so:	libsundown.so.1
 	ln -f -s $^ $@
 
 libsundown.so.1: $(SUNDOWN_SRC)
-	$(CC) $(LDFLAGS) -shared -Wl $^ -o $@
+	$(CC) $(LDFLAGS) -shared $^ -o $@
 
 # executables
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,16 @@
-﻿Sundown
+Sundown
 =======
 
 `Sundown` is a Markdown parser based on the original code of the
 [Upskirt library](http://fossil.instinctive.eu/libupskirt/index) by Natacha Porté.
+
+
+About this Fork
+---------------
+This fork was made to facilitate Markdown AST construction based on renderer callbacks. Additional callbacks are added to avoid misusing string-oriented output buffer and provide support for nested markdown blocks AST construction.
+
+This fork is used in [Apiary.io](http://apiary.io) API Blueprint parser - [Snowcrash](http://https://github.com/apiaryio/snowcrash).
+
 
 Features
 --------

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ About this Fork
 ---------------
 This fork was made to facilitate Markdown AST construction based on renderer callbacks. Additional callbacks are added to avoid misusing string-oriented output buffer and provide support for nested markdown blocks AST construction.
 
-This fork is used in [Apiary.io](http://apiary.io) API Blueprint parser - [Snowcrash](http://https://github.com/apiaryio/snowcrash).
+This fork is used in [Apiary.io](http://apiary.io) API Blueprint parser - [Snowcrash](https://github.com/apiaryio/snowcrash).
 
 
 Features

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,9 @@ Sundown
 
 About this Fork
 ---------------
-This fork was made to facilitate Markdown AST construction based on renderer callbacks. Additional callbacks are added to avoid misusing string-oriented output buffer and provide support for nested markdown blocks AST construction.
+This fork was made to facilitate Markdown AST construction based on renderer callbacks. Additional callbacks added to provide support for nested markdown blocks AST construction.
+
+Also included source map support - mapping parsed markdown blocks to its source text input.
 
 This fork is used in [Apiary.io](http://apiary.io) API Blueprint parser - [Snowcrash](https://github.com/apiaryio/snowcrash).
 

--- a/html/html.c
+++ b/html/html.c
@@ -577,8 +577,6 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		NULL,
 		NULL,
 
-        NULL,
-        NULL,
         NULL
 	};
 
@@ -626,8 +624,6 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		NULL,
 		NULL,
         
-        NULL,
-        NULL,
         NULL
 	};
 

--- a/html/html.c
+++ b/html/html.c
@@ -572,6 +572,10 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 
 		NULL,
 		toc_finalize,
+
+		NULL,
+		NULL,
+		NULL		
 	};
 
 	memset(options, 0x0, sizeof(struct html_renderopt));
@@ -613,6 +617,10 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 
 		NULL,
 		NULL,
+
+		NULL,
+		NULL,
+		NULL
 	};
 
 	/* Prepare the options pointer */

--- a/html/html.c
+++ b/html/html.c
@@ -575,7 +575,11 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 
 		NULL,
 		NULL,
-		NULL		
+		NULL,
+
+        NULL,
+        NULL,
+        NULL
 	};
 
 	memset(options, 0x0, sizeof(struct html_renderopt));
@@ -620,7 +624,11 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 
 		NULL,
 		NULL,
-		NULL
+		NULL,
+        
+        NULL,
+        NULL,
+        NULL
 	};
 
 	/* Prepare the options pointer */

--- a/src/autolink.h
+++ b/src/autolink.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 enum {
-	SD_AUTOLINK_SHORT_DOMAINS = (1 << 0),
+	SD_AUTOLINK_SHORT_DOMAINS = (1 << 0)
 };
 
 int

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -33,7 +33,7 @@ extern "C" {
 
 typedef enum {
 	BUF_OK = 0,
-	BUF_ENOMEM = -1,
+	BUF_ENOMEM = -1
 } buferror_t;
 
 /* struct buf: character array buffer */

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #if defined(_MSC_VER)
 #define __attribute__(x)
-#define inline
+#define inline __inline
 #endif
 
 typedef enum {

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1769,6 +1769,12 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 
 		in_empty = 0;
 
+        /* If there is a line which is a heading it isn't a line item. */
+        if (end > beg && !in_empty && data[beg] == '#') {
+            *flags |= MKD_LI_END;
+            break;
+        }
+
         /* source map */
         if (map) {
             size_t line_cur = src_map_location(map, beg + i);

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1769,8 +1769,8 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 
 		in_empty = 0;
 
-        /* If there is a line which is a heading it isn't a line item. */
-        if (end > beg && !in_empty && data[beg] == '#') {
+        /* If there is a line which is a heading, it isn't a line item. */
+        if (end > beg && !in_empty && (data[beg] == '#' || is_next_headerline(data + beg, end - beg) != 0)) {
             *flags |= MKD_LI_END;
             break;
         }

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2622,9 +2622,12 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 		beg += 3;
 
 	while (beg < doc_size) /* iterating over lines */
-		if (is_ref(document, beg, doc_size, &end, md->refs))
+		if (is_ref(document, beg, doc_size, &end, md->refs)) {
+			if (end > beg)
+				expand_tabs(text, document + beg, end - beg);
+
 			beg = end;
-		else { /* skipping to the next line */
+		} else { /* skipping to the next line */
 			end = beg;
 			while (end < doc_size && document[end] != '\n' && document[end] != '\r')
 				end++;

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2283,7 +2283,7 @@ parse_table(
 static void
 parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, const src_map *map)
 {
-	size_t beg, end, i, block_beg, empty;
+	size_t beg, end, i, block_beg;
 	uint8_t *txt_data;
 	beg = 0;
 
@@ -2293,7 +2293,6 @@ parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 	while (beg < size) {
         block_beg = beg;
-        empty = 0;
 		txt_data = data + beg;
 		end = size - beg;
         
@@ -2316,7 +2315,6 @@ parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 
 		else if ((i = is_empty(txt_data, end)) != 0) {
 			beg += i;
-            empty = i;
         }
 
 		else if (is_hrule(txt_data, end)) {

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1786,7 +1786,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 	}
 
 	/* render of li contents */
-	if (has_inside_empty)
+	//if (has_inside_empty)
 		*flags |= MKD_LI_BLOCK;
 
 	if (*flags & MKD_LI_BLOCK) {

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1656,7 +1656,7 @@ static size_t
 parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int *flags, const src_map *map)
 {
 	struct buf *work = 0, *inter = 0;
-	size_t beg = 0, end, pre, sublist = 0, orgpre = 0, i;
+	size_t beg = 0, end, pre, sublist = 0, orgpre = 0, i = 0;
 	int in_empty = 0, has_inside_empty = 0, in_fence = 0;
 
 	/* keeping track of the first indentation prefix */

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1656,7 +1656,7 @@ static size_t
 parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size, int *flags, const src_map *map)
 {
 	struct buf *work = 0, *inter = 0;
-	size_t beg = 0, end, pre, sublist = 0, orgpre = 0, i = 0;
+	size_t beg = 0, end, sublist = 0, orgpre = 0, i = 0;
 	int in_empty = 0, has_inside_empty = 0, in_fence = 0;
     src_map *item_map = NULL;
     src_map *whole_item_map = NULL;
@@ -1717,8 +1717,6 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 		while (i < 4 && beg + i < end && data[beg + i] == ' ')
 			i++;
 
-		pre = i;
-
 		if (rndr->ext_flags & MKDEXT_FENCED_CODE) {
 			if (is_codefence(data + beg + i, end - beg - i, NULL) != 0)
 				in_fence = !in_fence;
@@ -1744,7 +1742,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 			if (in_empty)
 				has_inside_empty = 1;
 
-			if (pre == orgpre) /* the following item must have */
+			if (i <= orgpre) /* the following item must have */
 				break;             /* the same indentation */
 
 			if (!sublist)
@@ -1753,7 +1751,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 		/* joining only indented stuff after empty lines;
 		 * note that now we only require 1 space of indentation
 		 * to continue a list */
-		else if (in_empty && pre == 0) {
+		else if (in_empty && i == 0) {
 			*flags |= MKD_LI_END;
 			break;
 		}
@@ -1770,7 +1768,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 		in_empty = 0;
 
         /* If there is a line which is a heading, it isn't a line item. */
-        if (end > beg && !in_empty && (data[beg] == '#' || is_next_headerline(data + beg, end - beg) != 0)) {
+        if (end > beg && (data[beg] == '#' || is_next_headerline(data + beg, end - beg) != 0)) {
             *flags |= MKD_LI_END;
             break;
         }

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2639,15 +2639,15 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 
 	if (text->size) {
 
+		/* adding a final newline if not already present */
+		if (text->data[text->size - 1] != '\n' &&  text->data[text->size - 1] != '\r')
+			bufputc(text, '\n');
+
         /* source map */
         if (map) {
             range rng = {0, text->size};
             src_map_append(map, &rng);
         }
-        
-		/* adding a final newline if not already present */
-		if (text->data[text->size - 1] != '\n' &&  text->data[text->size - 1] != '\r')
-			bufputc(text, '\n');
         
 		parse_block(ob, md, text->data, text->size, map);
         

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2164,6 +2164,9 @@ parse_table_header(
 	if (header_end && data[header_end - 1] == '|')
 		pipes--;
 
+    if (pipes < 0)
+        return 0;
+    
 	*columns = pipes + 1;
 	*column_data = calloc(*columns, sizeof(int));
 

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1391,6 +1391,10 @@ parse_blockquote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t
 	uint8_t *work_data = 0;
 	struct buf *out = 0;
 
+	/* AST construction */
+	if (rndr->cb.blockquote_begin)
+		rndr->cb.blockquote_begin(rndr->opaque);
+
 	out = rndr_newbuf(rndr, BUFFER_BLOCK);
 	beg = 0;
 	while (beg < size) {
@@ -1643,6 +1647,10 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 	if (!beg)
 		return 0;
 
+	/* AST construction */
+	if (rndr->cb.listitem_begin)
+		rndr->cb.listitem_begin(*flags, rndr->opaque);
+
 	/* skipping to the beginning of the following line */
 	end = beg;
 	while (end < size && data[end - 1] != '\n')
@@ -1767,6 +1775,10 @@ parse_list(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size,
 {
 	struct buf *work = 0;
 	size_t i = 0, j;
+
+	/* AST construction */
+	if (rndr->cb.list_begin)
+		rndr->cb.list_begin(flags, rndr->opaque);
 
 	work = rndr_newbuf(rndr, BUFFER_BLOCK);
 

--- a/src/markdown.c
+++ b/src/markdown.c
@@ -1659,6 +1659,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 	size_t beg = 0, end, pre, sublist = 0, orgpre = 0, i = 0;
 	int in_empty = 0, has_inside_empty = 0, in_fence = 0;
     src_map *item_map = NULL;
+    src_map *whole_item_map = NULL;
     
 	/* keeping track of the first indentation prefix */
 	while (orgpre < 3 && orgpre < size && data[orgpre] == ' ')
@@ -1793,7 +1794,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
             
             /* source map */
             if (item_map)
-                sublist_map = src_map_new_tail(item_map, sublist);
+                sublist_map = src_map_new_tail(item_map, sublist, -1);
             
 			parse_block(inter, rndr, work->data + sublist, work->size - sublist, sublist_map);
             
@@ -1811,7 +1812,7 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
             
             /* source map */
             if (item_map)
-                sublist_map = src_map_new_tail(item_map, sublist);
+                sublist_map = src_map_new_tail(item_map, sublist, -1);
 
 			parse_block(inter, rndr, work->data + sublist, work->size - sublist, sublist_map);
             
@@ -1828,10 +1829,15 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
     
     /* source map */
     if (item_map) {
+        range r = { orgpre, beg };
+
+        whole_item_map = src_map_new_tail(map, r.loc, r.len);
+        
         if (rndr->cb.block_did_parse)
-            rndr->cb.block_did_parse(item_map, data + i, size - i, rndr->opaque);
+            rndr->cb.block_did_parse(whole_item_map, data + i, size - i, rndr->opaque);
         
         src_map_release(item_map);
+        src_map_release(whole_item_map);
     }
 
 	rndr_popbuf(rndr, BUFFER_SPAN);

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -102,6 +102,11 @@ struct sd_callbacks {
 	void (*blockquote_begin)(void *opaque);
 	void (*list_begin)(int flags, void *opaque);
 	void (*listitem_begin)(int flags, void *opaque);
+    
+    /* Source data collection */
+    void (*block_parse_begin)(void *opaque);
+    void (*block_parse_end)(void *opaque);
+    void (*block_did_parse)(size_t cur, const uint8_t *txt_data, size_t size, size_t empty, void *opaque);
 };
 
 struct sd_markdown;

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -21,6 +21,7 @@
 
 #include "buffer.h"
 #include "autolink.h"
+#include "src_map.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -103,10 +104,8 @@ struct sd_callbacks {
 	void (*list_begin)(int flags, void *opaque);
 	void (*listitem_begin)(int flags, void *opaque);
     
-    /* Source data collection */
-    void (*block_parse_begin)(void *opaque);
-    void (*block_parse_end)(void *opaque);
-    void (*block_did_parse)(size_t cur, const uint8_t *txt_data, size_t size, size_t empty, void *opaque);
+    /* source map */
+    void (*block_did_parse)(const src_map* map, const uint8_t *txt_data, size_t size, void *opaque);
 };
 
 struct sd_markdown;

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -40,7 +40,7 @@ extern "C" {
 enum mkd_autolink {
 	MKDA_NOT_AUTOLINK,	/* used internally when it is not an autolink*/
 	MKDA_NORMAL,		/* normal http/http/ftp/mailto/etc link */
-	MKDA_EMAIL,			/* e-mail link without explit mailto: */
+	MKDA_EMAIL			/* e-mail link without explit mailto: */
 };
 
 enum mkd_tableflags {
@@ -59,7 +59,7 @@ enum mkd_extensions {
 	MKDEXT_STRIKETHROUGH = (1 << 4),
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
-	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_LAX_SPACING = (1 << 8)
 };
 
 /* sd_callbacks - functions for rendering parsed data */

--- a/src/markdown.h
+++ b/src/markdown.h
@@ -97,6 +97,11 @@ struct sd_callbacks {
 	/* header and footer */
 	void (*doc_header)(struct buf *ob, void *opaque);
 	void (*doc_footer)(struct buf *ob, void *opaque);
+
+	/* AST construction helpers */
+	void (*blockquote_begin)(void *opaque);
+	void (*list_begin)(int flags, void *opaque);
+	void (*listitem_begin)(int flags, void *opaque);
 };
 
 struct sd_markdown;

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -1,0 +1,191 @@
+/*
+ * src_map.c
+ * snowcrash
+ *
+ * Created by Zdenek Nemec on 4/21/13.
+ * Copyright (c) 2013 Apiary.io. All rights reserved.
+ */
+
+#include "src_map.h"
+
+#include <assert.h>
+
+range *
+range_new(size_t loc, size_t len)
+{
+    range *r;
+    if((r = malloc(sizeof *r)) != NULL) {
+        r->loc = loc;
+        r->len = len;
+    }
+    
+    return r;
+}
+
+void
+range_release(range *r)
+{
+    if (!r)
+        return;
+    
+    free(r);
+    r = NULL;
+}
+
+src_map *
+src_map_new()
+{
+    src_map *map;
+    if ((map = malloc(sizeof *map)) != NULL) {
+        stack_init(map, 4);
+    }
+    
+    return map;
+}
+
+void
+src_map_release(src_map *map)
+{
+    if (!map)
+        return;
+    
+    size_t i;
+	for (i = 0; i < (size_t)map->asize; ++i) {
+		range_release(map->item[i]);
+    }
+    
+    stack_free(map);
+    free(map);
+    map = NULL;
+}
+
+src_map *
+src_map_new_submap(const src_map *map, const range *r)
+{
+    if (!map ||
+        !map->size ||
+        !r ||
+        !r->len)
+        return NULL;
+
+    /* find first item */
+    size_t i;
+    size_t first_item = -1;
+	for (i = 0; i < (size_t)map->size; ++i) {
+        
+        range *it = (range *)map->item[i];
+        if (r->loc >= it->loc &&
+            r->loc < it->loc + it->len) {
+            first_item = i;
+            break;
+        }
+    }
+    
+    if (first_item == -1)
+        return NULL;
+    
+    /* create new map */
+    src_map *new_map = src_map_new();
+    size_t remain_len = r->len;
+    
+	for (i = first_item; i < (size_t)map->size; ++i) {
+
+        range *it = (range *)map->item[i];
+        size_t add_loc = (i == first_item) ? r->loc : it->loc;
+        size_t add_len = (it->len < remain_len) ? it->len : remain_len;
+        
+        range *add_range = range_new(add_loc, add_len);
+        stack_push(new_map, add_range);
+        
+        remain_len -= add_len;
+        
+        if (remain_len <= 0)
+            break;
+    }
+
+    return new_map;
+}
+
+/* append range to src_map */
+void
+src_map_append(src_map *map, const range *r)
+{
+    if (!map ||
+        !r ||
+        !r->len)
+        return;
+    
+    if (map->size) {
+        /* check continuous range */
+        range *last_range = (range *)map->item[map->size - 1];
+        if (r->loc == last_range->loc + last_range->len) {
+            last_range->len += r->loc;
+            return;
+        }
+    }
+
+    /* not continuous, create new range and push */
+    range *new_range = range_new(r->loc, r->len);
+    stack_push(map, new_range);
+}
+
+/* return index-th cursor from map */
+size_t
+src_map_location(const src_map *map, size_t index)
+{
+    if (!map ||
+        !map->size)
+        return -1;
+    
+    size_t i;
+    size_t cur = 0;
+	for (i = 0; i < (size_t)map->size; ++i) {
+
+        range *it = (range *)map->item[i];
+        if (index < cur + it->len) {
+            return it->loc + index - cur;
+        }
+        cur += it->len;
+    }
+
+ 	assert(0);
+    return -1;
+}
+
+/* create new src_map from index onward */
+src_map *
+src_map_new_tail(const src_map *map, size_t index)
+{
+    if (!map ||
+        !map->size)
+        return NULL;
+    
+    size_t i;
+    size_t cur = 0;
+    size_t first_item = -1;
+	for (i = 0; i < (size_t)map->size; ++i) {
+        
+        range *it = (range *)map->item[i];
+        if (index < cur + it->len) {
+            first_item = i;
+            break;
+        }
+        cur += it->len;
+    }
+
+    if (first_item == -1)
+        return NULL;
+    
+    /* create new map */
+    src_map *new_map = src_map_new();
+    
+	for (i = first_item; i < map->size; ++i) {
+        
+        range *it = (range *)map->item[i];
+        range *add_range = range_new(it->loc, it->len);
+        stack_push(new_map, add_range);
+        
+    }
+    
+    return new_map;
+}

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -125,7 +125,7 @@ src_map_append(src_map *map, const range *r)
         /* check continuous range */
         range *last_range = (range *)map->item[map->size - 1];
         if (r->loc <= last_range->loc + last_range->len) {
-            last_range->len += r->len - (last_range->len - r->loc);
+            last_range->len += r->len - (last_range->loc + last_range->len - r->loc);
             return;
         }
     }

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -46,10 +46,11 @@ src_map_new()
 void
 src_map_release(src_map *map)
 {
+    size_t i = 0;
+
     if (!map)
         return;
     
-    size_t i;
 	for (i = 0; i < (size_t)map->asize; ++i) {
 		range_release(map->item[i]);
     }
@@ -62,6 +63,11 @@ src_map_release(src_map *map)
 src_map *
 src_map_new_submap(const src_map *map, const range *r)
 {
+    size_t i;
+    size_t first_item = -1;
+    src_map *new_map = NULL;
+    size_t remain_len = 0;
+    
     if (!map ||
         !map->size ||
         !r ||
@@ -69,8 +75,6 @@ src_map_new_submap(const src_map *map, const range *r)
         return NULL;
 
     /* find first item */
-    size_t i;
-    size_t first_item = -1;
 	for (i = 0; i < (size_t)map->size; ++i) {
         
         range *it = (range *)map->item[i];
@@ -85,8 +89,8 @@ src_map_new_submap(const src_map *map, const range *r)
         return NULL;
     
     /* create new map */
-    src_map *new_map = src_map_new();
-    size_t remain_len = r->len;
+    new_map = src_map_new();
+    remain_len = r->len;
     
 	for (i = first_item; i < (size_t)map->size; ++i) {
 
@@ -110,6 +114,8 @@ src_map_new_submap(const src_map *map, const range *r)
 void
 src_map_append(src_map *map, const range *r)
 {
+    range *new_range = NULL;
+    
     if (!map ||
         !r ||
         !r->len)
@@ -125,7 +131,7 @@ src_map_append(src_map *map, const range *r)
     }
 
     /* not continuous, create new range and push */
-    range *new_range = range_new(r->loc, r->len);
+    new_range = range_new(r->loc, r->len);
     stack_push(map, new_range);
 }
 
@@ -133,12 +139,13 @@ src_map_append(src_map *map, const range *r)
 size_t
 src_map_location(const src_map *map, size_t index)
 {
+    size_t i = 0;
+    size_t cur = 0;
+    
     if (!map ||
         !map->size)
         return -1;
     
-    size_t i;
-    size_t cur = 0;
 	for (i = 0; i < (size_t)map->size; ++i) {
 
         range *it = (range *)map->item[i];
@@ -156,13 +163,15 @@ src_map_location(const src_map *map, size_t index)
 src_map *
 src_map_new_tail(const src_map *map, size_t index)
 {
+    size_t i = 0;
+    size_t cur = 0;
+    size_t first_item = -1;
+    src_map *new_map = NULL;
+    
     if (!map ||
         !map->size)
         return NULL;
     
-    size_t i;
-    size_t cur = 0;
-    size_t first_item = -1;
 	for (i = 0; i < (size_t)map->size; ++i) {
         
         range *it = (range *)map->item[i];
@@ -177,7 +186,7 @@ src_map_new_tail(const src_map *map, size_t index)
         return NULL;
     
     /* create new map */
-    src_map *new_map = src_map_new();
+    new_map = src_map_new();
     
 	for (i = first_item; i < map->size; ++i) {
         

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -124,8 +124,8 @@ src_map_append(src_map *map, const range *r)
     if (map->size) {
         /* check continuous range */
         range *last_range = (range *)map->item[map->size - 1];
-        if (r->loc == last_range->loc + last_range->len) {
-            last_range->len += r->len;
+        if (r->loc <= last_range->loc + last_range->len) {
+            last_range->len += r->len - (last_range->len - r->loc);
             return;
         }
     }
@@ -161,11 +161,12 @@ src_map_location(const src_map *map, size_t index)
 
 /* create new src_map from index onward */
 src_map *
-src_map_new_tail(const src_map *map, size_t index)
+src_map_new_tail(const src_map *map, size_t index, size_t maxlen)
 {
     size_t i = 0;
     size_t cur = 0;
     size_t first_item = -1;
+    size_t count = 0;
     src_map *new_map = NULL;
     
     if (!map ||
@@ -187,13 +188,19 @@ src_map_new_tail(const src_map *map, size_t index)
     
     /* create new map */
     new_map = src_map_new();
-    
 	for (i = first_item; i < map->size; ++i) {
         
+        if (count >= maxlen)
+            break;
+
         range *it = (range *)map->item[i];
         range *add_range = range_new(it->loc, it->len);
-        stack_push(new_map, add_range);
         
+        if (count + it->len > maxlen) {
+            add_range->len = maxlen - count;
+        }
+        count += it->len;
+        stack_push(new_map, add_range);   
     }
     
     return new_map;

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -188,10 +188,7 @@ src_map_new_tail(const src_map *map, size_t index, size_t maxlen)
     
     /* create new map */
     new_map = src_map_new();
-	for (i = first_item; i < map->size; ++i) {
-        
-        if (count >= maxlen)
-            break;
+	for (i = first_item; i < map->size && count < maxlen; ++i) {
 
         range *it = (range *)map->item[i];
         range *add_range = range_new(it->loc, it->len);

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -3,7 +3,7 @@
  * snowcrash
  *
  * Created by Zdenek Nemec on 4/21/13.
- * Copyright (c) 2013 Apiary.io. All rights reserved.
+ * Copyright (c) 2013 Apiary Inc. All rights reserved.
  */
 
 #include "src_map.h"

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -125,7 +125,7 @@ src_map_append(src_map *map, const range *r)
         /* check continuous range */
         range *last_range = (range *)map->item[map->size - 1];
         if (r->loc == last_range->loc + last_range->len) {
-            last_range->len += r->loc;
+            last_range->len += r->len;
             return;
         }
     }

--- a/src/src_map.c
+++ b/src/src_map.c
@@ -81,7 +81,7 @@ src_map_new_submap(const src_map *map, const range *r)
         }
     }
     
-    if (first_item == -1)
+    if (first_item == (size_t)-1)
         return NULL;
     
     /* create new map */
@@ -173,7 +173,7 @@ src_map_new_tail(const src_map *map, size_t index)
         cur += it->len;
     }
 
-    if (first_item == -1)
+    if (first_item == (size_t)-1)
         return NULL;
     
     /* create new map */

--- a/src/src_map.h
+++ b/src/src_map.h
@@ -42,7 +42,7 @@ void src_map_release(src_map *map);
 src_map *src_map_new_submap(const src_map *map, const range *r);
 
 /* src_map_new_tail: create map from tail of map */
-src_map *src_map_new_tail(const src_map *map, size_t index);
+src_map *src_map_new_tail(const src_map *map, size_t index, size_t maxlen);
     
 /* src_map_append: append range to source map */
 void src_map_append(src_map *map, const range *r);

--- a/src/src_map.h
+++ b/src/src_map.h
@@ -1,0 +1,58 @@
+/*
+ * src_map.h
+ * snowcrash
+ *
+ * Created by Zdenek Nemec on 4/21/13.
+ * Copyright (c) 2013 Apiary.io. All rights reserved.
+ *
+ */
+
+#ifndef SNOWCRASH_SUNDOWN_SRCMAP_H
+#define SNOWCRASH_SUNDOWN_SRCMAP_H
+
+#include <stdlib.h>
+#include "stack.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
+/* range: character data range */
+typedef struct {
+    size_t loc;
+    size_t len;
+} range;
+
+/* range_new: allocate & init new range */
+range *range_new(size_t loc, size_t len);
+
+/* range_new: release range */
+void range_release(range *r);
+
+/* stack of range forming the buffer content */
+typedef struct stack src_map;
+
+/* src_map_new: allocate new source map */
+src_map *src_map_new();
+    
+/* src_map_release: release source map */
+void src_map_release(src_map *map);
+    
+/* src_map_submap: create map from a subset of map */
+src_map *src_map_new_submap(const src_map *map, const range *r);
+
+/* src_map_new_tail: create map from tail of map */
+src_map *src_map_new_tail(const src_map *map, size_t index);
+    
+/* src_map_append: append range to source map */
+void src_map_append(src_map *map, const range *r);
+    
+/* src_map_location: returns location in source for given index */
+size_t src_map_location(const src_map *map, size_t index);
+
+    
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/src_map.h
+++ b/src/src_map.h
@@ -3,7 +3,7 @@
  * snowcrash
  *
  * Created by Zdenek Nemec on 4/21/13.
- * Copyright (c) 2013 Apiary.io. All rights reserved.
+ * Copyright (c) 2013 Apiary Inc. All rights reserved.
  *
  */
 


### PR DESCRIPTION

    Fix behavior for lists
    
    there were diferent result (in sourcemap)
    ```
    + a
      b
    + c
    ```
    
    and
    
    ```
    + a
      b
    
    + c
    ```
    
    First one is parsed as "span" - both lines in one block
    Second one was parsed with as "two line block"
    
    This fix make same behavior for sourcemaps for both cases

