### PR TITLE
Fix to parse table rows with escaped '\|'

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -2011,7 +2011,7 @@ parse_table_row(
 
 		cell_start = i;
 
-		while (i < size && data[i] != '|')
+		while (i < size && ((data[i] != '|') || ((i > 0) && (data[i-1] == '\\'))))
 			i++;
 
 		cell_end = i - 1;


### PR DESCRIPTION
This is a fix to allow correctly parse tables with vertical bar escaped see bellow from https://github.com/mity/md4c :

``` example
Column 1 | Column 2
---------|---------
foo      | bar
baz      | qux \| xyzzy
quux     | quuz
.
<table>
<thead>
<tr><th>Column 1</th><th>Column 2</th></tr>
</thead>
<tbody>
<tr><td>foo</td><td>bar</td></tr>
<tr><td>baz</td><td>qux | xyzzy</td></tr>
<tr><td>quux</td><td>quuz</td></tr>
</tbody>
</table>
```