### PR TITLE
fix upskirt name/uri

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
 ﻿Sundown
 =======
 
-`Sundown` is a Markdown parser based on the original code of the
-[Upskirt library](http://fossil.instinctive.eu/libupskirt/index) by Natacha Porté.
+`Sundown` is a Markdown parser based on the original code of 
+[libsoldout](http://fossil.instinctive.eu/) by Natacha Porté.
 
 Features
 --------


### PR DESCRIPTION
the link to the upskirt library was broken and upstream have renamed it to libsoldout anyway; update both